### PR TITLE
Highlighting crucial APP_ID configuration step

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Coon is an Alfred workflow which do currency conversion by using live currency r
 
 * Config can be set in [workflow environment variables sheet](https://www.alfredapp.com/help/workflows/advanced/variables/#environment), by pressing `[x]` icon in Alfred Preferences
 * Settings is a json file located at `~/Library/Application Support/Alfred/Workflow Data/tech.tomy.coon`, or type the magic arguments `cur workflow:opendata` in Alfred will take you diractly to that diractory
-* Please setup your `APP_ID` before your first run, otherwise this workflow won't even work, at all.
+* Please **setup your `APP_ID` before your first run**, otherwise this workflow won't even work, at all.
 
 | Type     | Name        | Function                                                     | Default                        |
 | -------- | ----------- | ------------------------------------------------------------ | ------------------------------ |


### PR DESCRIPTION
As the user **must** declare the APP_ID before even starting the workflow, IMHO that instruction should be highlighted.